### PR TITLE
Check beta and minimum Rust versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,10 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
+        rust: [ stable, beta, 1.42.0 ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
- Check that we do not require a newer Rust version than we advertise supporting
- Check that we are not going to break on the next beta